### PR TITLE
Adds credits screen script to navigate to/fro

### DIFF
--- a/Scenes/Credits.tscn
+++ b/Scenes/Credits.tscn
@@ -5,12 +5,16 @@
 [ext_resource path="res://assets/pixelmix.ttf" type="DynamicFontData" id=3]
 [ext_resource path="res://assets/sprites/board.png" type="Texture" id=4]
 [ext_resource path="res://assets/sprites/ema.png" type="Texture" id=5]
+[ext_resource path="res://Scripts/Scenes/CreditsScreen.cs" type="Script" id=6]
 
 [sub_resource type="DynamicFont" id=1]
 size = 31
 font_data = ExtResource( 3 )
 
-[node name="Control" type="Control"]
+[node name="CreditsScreen" type="Node2D"]
+script = ExtResource( 6 )
+
+[node name="Control" type="Control" parent="."]
 anchor_right = 1.0
 anchor_bottom = 1.0
 

--- a/Scripts/Scenes/CreditsScreen.cs
+++ b/Scripts/Scenes/CreditsScreen.cs
@@ -1,0 +1,30 @@
+using Godot;
+using System;
+
+public class CreditsScreen : SceneBase
+{
+	// Called when the node enters the scene tree for the first time.
+	public override void _Ready()
+	{
+		base._Ready();
+		isGameplay = false;
+	}
+
+	public void _on_any_input_pressed()
+	{
+		GetTree().ChangeScene("res://Scenes/Start.tscn");
+	}
+	
+	public override void _Input(InputEvent @event)
+	{
+		if (@event is InputEventKey eventKey) {
+			if (eventKey.Pressed == true) {
+				_on_any_input_pressed();
+			}
+		}
+		if (@event is InputEventMouseButton eventMouseButton) {
+			_on_any_input_pressed();
+		}
+	}
+
+}


### PR DESCRIPTION
Any key press or mouse click will exit the credit screen. The credit screen can be entered from the start-up menu.